### PR TITLE
feat: AUM-ranked primary + backup ETF holdings per index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `from_str_id`, `as_str`, `cik::entry_for` (iShares Trust CIK
   0001100663, series S000004361) and `sponsor_url` (IWM via the
   iShares CSV CDN).
+- `sponsor::sponsor_urls(IndexId) -> Vec<(DataSource, &'static str,
+  &'static str)>` returns AUM-ranked endpoints (primary first,
+  backups follow). Per-index ladder:
+  - SP500: SPY (SSGA SPDR XLSX) > IVV (iShares CSV)
+  - SP400: IJH (iShares CSV) > MDY (SSGA SPDR XLSX)
+  - SP600: IJR (iShares CSV) > SLY (SSGA SPDR XLSX)
+  - NDX: QQQ (Invesco JSON) > QQQM (Invesco JSON)
+  - DJIA: DIA only
+  - RUT: IWM only
+- `SponsorClient::fetch_today` now walks `sponsor_urls` and falls
+  back to each backup endpoint on 4xx / 5xx / network failure,
+  warn-logging the failed primary. Returns the source tag and bytes
+  of the first successful endpoint.
 
 ### Changed
 
@@ -26,9 +39,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `DataSource::SpdrCdn` instead of returning the
   `"SPDR XLSX not parseable in v1.0"` error. DIA daily holdings are
   fetched on every nightly run going forward.
-- `cli::cmd_wayback_backfill` now invokes `parse_spdr_xlsx` for
-  Wayback snapshots of SSGA `.xlsx` URLs, unblocking historical DIA
-  backfill from `web.archive.org`.
+- `cli::cmd_wayback_backfill` now iterates `sponsor_urls` per index
+  (not just the primary), unifying CDX + snapshot ingest across
+  primary and backup endpoints. Same parser dispatch (iShares CSV /
+  Invesco JSON / SPDR XLSX) per source tag.
+- **SP500 primary flipped from IVV to SPY.** SPY (~$650 B AUM,
+  SSGA SPDR XLSX) is larger than IVV (~$600 B, iShares CSV) and
+  uses the same parser path as DIA. IVV remains as the secondary
+  endpoint. VOO (Vanguard, ~$700 B) outranks both by AUM but is
+  deferred until a stable scraper for Vanguard's JS-rendered
+  holdings page exists.
+- `sponsor::sponsor_url` retained as a backwards-compatible thin
+  wrapper that returns the first (primary) entry of `sponsor_urls`.
 
 ## [1.0.1] - 2026-04-24
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -31,7 +31,7 @@ use indexkit::nport::holdings_to_constituents;
 use indexkit::parquet_io::{read_month, write_month};
 use indexkit::sec::SecClient;
 use indexkit::sponsor::{
-    parse_invesco_csv, parse_ishares_csv, parse_spdr_xlsx, sponsor_url, SponsorClient,
+    parse_invesco_csv, parse_ishares_csv, parse_spdr_xlsx, sponsor_urls, SponsorClient,
 };
 use indexkit::types::DataSource;
 use indexkit::wayback::WaybackClient;
@@ -398,49 +398,62 @@ async fn cmd_wayback_backfill(
     let to_yyyymmdd = to_nd.format("%Y%m%d").to_string();
 
     for idx in indices {
-        let Some((source, _ticker, url)) = sponsor_url(idx) else {
+        let endpoints = sponsor_urls(idx);
+        if endpoints.is_empty() {
             continue;
-        };
-        println!(
-            "{idx}: listing Wayback snapshots {} -> {} for {}",
-            from_yyyymmdd, to_yyyymmdd, url
-        );
-        let matches = match wb.list(url, &from_yyyymmdd, &to_yyyymmdd).await {
-            Ok(m) => m,
-            Err(e) => {
-                tracing::warn!(%idx, "CDX fetch failed: {e}");
-                continue;
-            }
-        };
-        println!("{idx}: {} snapshots found", matches.len());
+        }
 
         let mut by_month: BTreeMap<YearMonth, Vec<Constituent>> = BTreeMap::new();
-        for m in matches {
-            let Some(d) = m.date() else { continue };
-            let ym = YearMonth::new(d.year(), d.month()).unwrap();
-            let body = match wb.fetch(&m).await {
-                Ok(b) => b,
+        for (source, ticker, url) in endpoints {
+            println!(
+                "{idx}/{ticker}: listing Wayback snapshots {} -> {} for {}",
+                from_yyyymmdd, to_yyyymmdd, url
+            );
+            let matches = match wb.list(url, &from_yyyymmdd, &to_yyyymmdd).await {
+                Ok(m) => m,
                 Err(e) => {
-                    tracing::debug!("skip snapshot {}: {e}", m.snapshot_url());
+                    tracing::warn!(%idx, %ticker, "CDX fetch failed: {e}");
                     continue;
                 }
             };
-            let tag = DataSource::Wayback(m.timestamp[..8].to_string());
-            let rows = match source {
-                DataSource::IsharesCdn => {
-                    let Ok(text) = std::str::from_utf8(&body) else {
+            println!("{idx}/{ticker}: {} snapshots found", matches.len());
+
+            for m in matches {
+                let Some(d) = m.date() else { continue };
+                let ym = YearMonth::new(d.year(), d.month()).unwrap();
+                let body = match wb.fetch(&m).await {
+                    Ok(b) => b,
+                    Err(e) => {
+                        tracing::debug!("skip snapshot {}: {e}", m.snapshot_url());
                         continue;
-                    };
-                    match parse_ishares_csv(text, d, tag) {
-                        Ok(r) => r,
-                        Err(_) => continue,
                     }
-                }
-                DataSource::InvescoCdn => {
-                    let Ok(text) = std::str::from_utf8(&body) else {
-                        continue;
-                    };
-                    match parse_invesco_csv(text, d) {
+                };
+                let tag = DataSource::Wayback(m.timestamp[..8].to_string());
+                let rows = match source {
+                    DataSource::IsharesCdn => {
+                        let Ok(text) = std::str::from_utf8(&body) else {
+                            continue;
+                        };
+                        match parse_ishares_csv(text, d, tag) {
+                            Ok(r) => r,
+                            Err(_) => continue,
+                        }
+                    }
+                    DataSource::InvescoCdn => {
+                        let Ok(text) = std::str::from_utf8(&body) else {
+                            continue;
+                        };
+                        match parse_invesco_csv(text, d) {
+                            Ok(mut r) => {
+                                for row in &mut r {
+                                    row.source = DataSource::Wayback(m.timestamp[..8].to_string());
+                                }
+                                r
+                            }
+                            Err(_) => continue,
+                        }
+                    }
+                    DataSource::SpdrCdn => match parse_spdr_xlsx(&body, d) {
                         Ok(mut r) => {
                             for row in &mut r {
                                 row.source = DataSource::Wayback(m.timestamp[..8].to_string());
@@ -448,25 +461,16 @@ async fn cmd_wayback_backfill(
                             r
                         }
                         Err(_) => continue,
-                    }
+                    },
+                    _ => continue,
+                };
+                if !rows.is_empty() {
+                    by_month.entry(ym).or_default().extend(rows);
                 }
-                DataSource::SpdrCdn => match parse_spdr_xlsx(&body, d) {
-                    Ok(mut r) => {
-                        for row in &mut r {
-                            row.source = DataSource::Wayback(m.timestamp[..8].to_string());
-                        }
-                        r
-                    }
-                    Err(_) => continue,
-                },
-                _ => continue,
-            };
-            if !rows.is_empty() {
-                by_month.entry(ym).or_default().extend(rows);
             }
         }
 
-        // Merge per-month.
+        // Merge per-month across all endpoints.
         for (ym, rows) in by_month {
             let old = existing_rows(data_dir, idx.as_str(), ym);
             let merged = coalesce(vec![old, rows]);

--- a/crates/indexkit/src/sponsor.rs
+++ b/crates/indexkit/src/sponsor.rs
@@ -34,44 +34,95 @@ use std::time::Duration;
 /// mistaken for a malicious bot.
 pub const SPONSOR_USER_AGENT: &str = "indexkit/1.0 (+https://github.com/userFRM/indexkit)";
 
-/// URL for the live sponsor-CDN holdings file of an ETF proxy.
+/// Ordered list of sponsor-CDN endpoints for an ETF proxy index, ranked by
+/// AUM (primary first, backups follow). [`SponsorClient::fetch_today`] walks
+/// the list and returns the first successful 200, falling back to the next
+/// entry on 4xx/5xx/network failure.
 ///
-/// Returns `None` for indices where we do not have a sponsor CDN endpoint
-/// (all five are supported in v1.0 but the list is provided for forward
-/// compatibility).
-pub fn sponsor_url(index: IndexId) -> Option<(DataSource, &'static str, &'static str)> {
+/// AUM ranking is approximate (late-2025 / early-2026 figures) and prefers
+/// data-source robustness as a tie-breaker (clean XLSX/CSV endpoints over
+/// JS-rendered HTML pages). VOO outranks SPY by AUM but is omitted because
+/// Vanguard's holdings page has no clean machine-readable endpoint at the
+/// time of writing.
+///
+/// | Index | Primary             | Backup                         |
+/// |-------|---------------------|--------------------------------|
+/// | SP500 | SPY (SSGA SPDR XLSX) | IVV (iShares CSV)             |
+/// | SP400 | IJH (iShares CSV)   | MDY (SSGA SPDR XLSX)           |
+/// | SP600 | IJR (iShares CSV)   | SLY (SSGA SPDR XLSX)           |
+/// | NDX   | QQQ (Invesco JSON)  | QQQM (Invesco JSON, same Trust) |
+/// | DJIA  | DIA (SSGA SPDR XLSX) | (none — no comparable second)  |
+/// | RUT   | IWM (iShares CSV)   | (none — VTWO needs JS scraper) |
+pub fn sponsor_urls(index: IndexId) -> Vec<(DataSource, &'static str, &'static str)> {
     match index {
-        IndexId::Sp500 => Some((
-            DataSource::IsharesCdn,
-            "IVV",
-            "https://www.ishares.com/us/products/239726/ishares-core-sp-500-etf/1467271812596.ajax?fileType=csv&fileName=IVV_holdings&dataType=fund",
-        )),
-        IndexId::Sp400 => Some((
-            DataSource::IsharesCdn,
-            "IJH",
-            "https://www.ishares.com/us/products/239763/ishares-core-sp-midcap-etf/1467271812596.ajax?fileType=csv&fileName=IJH_holdings&dataType=fund",
-        )),
-        IndexId::Sp600 => Some((
-            DataSource::IsharesCdn,
-            "IJR",
-            "https://www.ishares.com/us/products/239774/ishares-core-sp-smallcap-etf/1467271812596.ajax?fileType=csv&fileName=IJR_holdings&dataType=fund",
-        )),
-        IndexId::Ndx => Some((
-            DataSource::InvescoCdn,
-            "QQQ",
-            "https://www.invesco.com/us/financial-products/etfs/holdings/main/holdings/0?audienceType=Investor&action=download&ticker=QQQ",
-        )),
-        IndexId::Dji => Some((
+        IndexId::Sp500 => vec![
+            (
+                DataSource::SpdrCdn,
+                "SPY",
+                "https://www.ssga.com/us/en/intermediary/library-content/products/fund-data/etfs/us/holdings-daily-us-en-spy.xlsx",
+            ),
+            (
+                DataSource::IsharesCdn,
+                "IVV",
+                "https://www.ishares.com/us/products/239726/ishares-core-sp-500-etf/1467271812596.ajax?fileType=csv&fileName=IVV_holdings&dataType=fund",
+            ),
+        ],
+        IndexId::Sp400 => vec![
+            (
+                DataSource::IsharesCdn,
+                "IJH",
+                "https://www.ishares.com/us/products/239763/ishares-core-sp-midcap-etf/1467271812596.ajax?fileType=csv&fileName=IJH_holdings&dataType=fund",
+            ),
+            (
+                DataSource::SpdrCdn,
+                "MDY",
+                "https://www.ssga.com/us/en/intermediary/library-content/products/fund-data/etfs/us/holdings-daily-us-en-mdy.xlsx",
+            ),
+        ],
+        IndexId::Sp600 => vec![
+            (
+                DataSource::IsharesCdn,
+                "IJR",
+                "https://www.ishares.com/us/products/239774/ishares-core-sp-smallcap-etf/1467271812596.ajax?fileType=csv&fileName=IJR_holdings&dataType=fund",
+            ),
+            (
+                DataSource::SpdrCdn,
+                "SLY",
+                "https://www.ssga.com/us/en/intermediary/library-content/products/fund-data/etfs/us/holdings-daily-us-en-sly.xlsx",
+            ),
+        ],
+        IndexId::Ndx => vec![
+            (
+                DataSource::InvescoCdn,
+                "QQQ",
+                "https://www.invesco.com/us/financial-products/etfs/holdings/main/holdings/0?audienceType=Investor&action=download&ticker=QQQ",
+            ),
+            (
+                DataSource::InvescoCdn,
+                "QQQM",
+                "https://www.invesco.com/us/financial-products/etfs/holdings/main/holdings/0?audienceType=Investor&action=download&ticker=QQQM",
+            ),
+        ],
+        IndexId::Dji => vec![(
             DataSource::SpdrCdn,
             "DIA",
             "https://www.ssga.com/us/en/intermediary/library-content/products/fund-data/etfs/us/holdings-daily-us-en-dia.xlsx",
-        )),
-        IndexId::Rut => Some((
+        )],
+        IndexId::Rut => vec![(
             DataSource::IsharesCdn,
             "IWM",
             "https://www.ishares.com/us/products/239710/ishares-russell-2000-etf/1467271812596.ajax?fileType=csv&fileName=IWM_holdings&dataType=fund",
-        )),
+        )],
     }
+}
+
+/// Primary sponsor-CDN endpoint (first entry of [`sponsor_urls`]).
+///
+/// Kept for backwards compatibility with v1.0 callers that only need the
+/// AUM-ranked primary. New code should prefer [`sponsor_urls`] to enable
+/// backup-fallback.
+pub fn sponsor_url(index: IndexId) -> Option<(DataSource, &'static str, &'static str)> {
+    sponsor_urls(index).into_iter().next()
 }
 
 /// Client for sponsor-CDN holdings files.
@@ -92,20 +143,43 @@ impl SponsorClient {
 
     /// Fetch today's sponsor-CDN holdings as raw bytes.
     ///
-    /// Returns [`Error::Nport`] (repurposed) if the fetch fails or the
-    /// index has no sponsor URL.
+    /// Walks [`sponsor_urls`] in AUM order: tries the primary first, falls
+    /// back to each backup on network failure or non-2xx response. Returns
+    /// the source tag and bytes of the first successful endpoint.
+    ///
+    /// Errors only when every endpoint fails or the index has no sponsor
+    /// entries at all.
     pub async fn fetch_today(&self, index: IndexId) -> Result<(DataSource, bytes::Bytes)> {
-        let (src, _ticker, url) = sponsor_url(index)
-            .ok_or_else(|| Error::Other(format!("no sponsor url for {index}")))?;
-        let resp = self.http.get(url).send().await?;
-        if !resp.status().is_success() {
-            return Err(Error::Other(format!(
-                "sponsor fetch {url}: HTTP {} {}",
-                resp.status().as_u16(),
-                resp.status().canonical_reason().unwrap_or("")
-            )));
+        let endpoints = sponsor_urls(index);
+        if endpoints.is_empty() {
+            return Err(Error::Other(format!("no sponsor url for {index}")));
         }
-        Ok((src, resp.bytes().await?))
+        let mut last_err: Option<String> = None;
+        for (src, ticker, url) in endpoints {
+            match self.http.get(url).send().await {
+                Ok(resp) if resp.status().is_success() => match resp.bytes().await {
+                    Ok(body) => return Ok((src, body)),
+                    Err(e) => {
+                        last_err = Some(format!("{ticker}: body read failed: {e}"));
+                        tracing::warn!(%index, %ticker, "sponsor body read failed: {e}");
+                    }
+                },
+                Ok(resp) => {
+                    let code = resp.status().as_u16();
+                    let reason = resp.status().canonical_reason().unwrap_or("");
+                    last_err = Some(format!("{ticker}: HTTP {code} {reason}"));
+                    tracing::warn!(%index, %ticker, "sponsor fetch HTTP {code} {reason}, trying next");
+                }
+                Err(e) => {
+                    last_err = Some(format!("{ticker}: {e}"));
+                    tracing::warn!(%index, %ticker, "sponsor fetch network error: {e}, trying next");
+                }
+            }
+        }
+        Err(Error::Other(format!(
+            "all sponsor endpoints failed for {index}: {}",
+            last_err.unwrap_or_else(|| "unknown".into())
+        )))
     }
 }
 
@@ -628,6 +702,56 @@ QQQ,594918104,MSFT,MICROSOFT CORP,4.81,47300000,19500000000,03/15/2024
         for id in IndexId::ALL {
             let url = sponsor_url(id);
             assert!(url.is_some(), "no sponsor url for {id}");
+        }
+    }
+
+    #[test]
+    fn sponsor_urls_aum_ranked_primary() {
+        // SP500 primary must be SPY (SSGA SPDR XLSX) by AUM, with IVV backup.
+        let sp500 = sponsor_urls(IndexId::Sp500);
+        assert_eq!(sp500.len(), 2);
+        assert_eq!(sp500[0].0, DataSource::SpdrCdn);
+        assert_eq!(sp500[0].1, "SPY");
+        assert!(sp500[0].2.ends_with("holdings-daily-us-en-spy.xlsx"));
+        assert_eq!(sp500[1].0, DataSource::IsharesCdn);
+        assert_eq!(sp500[1].1, "IVV");
+
+        // SP400: IJH primary, MDY backup.
+        let sp400 = sponsor_urls(IndexId::Sp400);
+        assert_eq!(sp400.len(), 2);
+        assert_eq!(sp400[0].1, "IJH");
+        assert_eq!(sp400[1].1, "MDY");
+
+        // SP600: IJR primary, SLY backup.
+        let sp600 = sponsor_urls(IndexId::Sp600);
+        assert_eq!(sp600.len(), 2);
+        assert_eq!(sp600[0].1, "IJR");
+        assert_eq!(sp600[1].1, "SLY");
+
+        // NDX: QQQ primary, QQQM backup.
+        let ndx = sponsor_urls(IndexId::Ndx);
+        assert_eq!(ndx.len(), 2);
+        assert_eq!(ndx[0].1, "QQQ");
+        assert_eq!(ndx[1].1, "QQQM");
+
+        // DJIA: DIA only.
+        let dji = sponsor_urls(IndexId::Dji);
+        assert_eq!(dji.len(), 1);
+        assert_eq!(dji[0].1, "DIA");
+
+        // RUT: IWM only.
+        let rut = sponsor_urls(IndexId::Rut);
+        assert_eq!(rut.len(), 1);
+        assert_eq!(rut[0].1, "IWM");
+    }
+
+    #[test]
+    fn sponsor_url_returns_first_of_sponsor_urls() {
+        for id in IndexId::ALL {
+            let single = sponsor_url(id).unwrap();
+            let first = sponsor_urls(id).into_iter().next().unwrap();
+            assert_eq!(single.1, first.1);
+            assert_eq!(single.2, first.2);
         }
     }
 


### PR DESCRIPTION
## Summary

- AUM-ranked sponsor endpoints per index (primary + backup), with automatic fallback on 4xx / 5xx / network failure.
- SP500 primary flipped IVV → SPY (SSGA SPDR XLSX, ~\$650B vs IVV's ~\$600B; also reuses the DIA parser path).
- New backup endpoints: MDY (SP400), SLY (SP600), QQQM (NDX).
- IVV / IJH / IJR / QQQ kept where they were primary; demoted to backup only on SP500.

## Per-index ladder

| Index | Primary | Backup |
|---|---|---|
| SP500 | **SPY** (SSGA SPDR XLSX) | IVV (iShares CSV) |
| SP400 | IJH (iShares CSV) | MDY (SSGA SPDR XLSX) |
| SP600 | IJR (iShares CSV) | SLY (SSGA SPDR XLSX) |
| NDX | QQQ (Invesco JSON) | QQQM (Invesco JSON) |
| DJIA | DIA (SSGA SPDR XLSX) | — |
| RUT | IWM (iShares CSV) | — |

VOO outranks SPY by AUM (~\$700B) but Vanguard's holdings page is JS-rendered with no clean machine-readable endpoint. Deferred to a follow-up issue once a stable scraper exists.

## Code surface

- New: `sponsor::sponsor_urls(IndexId) -> Vec<(DataSource, &'static str, &'static str)>`
- New: `SponsorClient::fetch_today` walks the list, warn-logs failed primaries, returns first success.
- Backwards-compat: `sponsor::sponsor_url` retained as a thin wrapper over `sponsor_urls().into_iter().next()`.
- `cli::cmd_wayback_backfill` iterates all endpoints per index (Wayback CDX coverage on backup tickers extends historical reach).

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --workspace` -- 79 + 18 doctests pass (was 77; +2 new tests: `sponsor_urls_aum_ranked_primary`, `sponsor_url_returns_first_of_sponsor_urls`)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [ ] CI green
- [ ] Tomorrow's nightly cron picks up SPY XLSX as the SP500 primary

Closes #3.